### PR TITLE
feat: Add ability to override rootContentDir for radarr and sonarr

### DIFF
--- a/server/src/aiarr.py
+++ b/server/src/aiarr.py
@@ -58,9 +58,11 @@ class AiArr:
         self.radarr_url = None
         self.radarr_api_key = None
         self.radarr_default_quality_profile_id = None
+        self.radarr_movies_path = None
         self.sonarr_url = None
         self.sonarr_api_key = None
         self.sonarr_default_quality_profile_id = None
+        self.sonarr_tvshows_path = None
         self.gemini_enabled = None 
         self.gemini_api_key = None
         self.gemini_model = None
@@ -117,9 +119,11 @@ class AiArr:
         self.radarr_url = self.settings.get("radarr", "url")
         self.radarr_api_key = self.settings.get("radarr", "api_key")
         self.radarr_default_quality_profile_id = self.settings.get("radarr", "default_quality_profile_id")
+        self.radarr_movies_path = self.settings.get("radarr", "movies_path")
         self.sonarr_url = self.settings.get("sonarr", "url")
         self.sonarr_api_key = self.settings.get("sonarr", "api_key")
         self.sonarr_default_quality_profile_id = self.settings.get("sonarr", "default_quality_profile_id")
+        self.sonarr_tvshows_path = self.settings.get("sonarr", "tvshows_path")
         self.gemini_enabled = self.settings.get("gemini", "enabled") 
         self.gemini_api_key = self.settings.get("gemini", "api_key")
         self.gemini_model = self.settings.get("gemini", "model")
@@ -176,10 +180,12 @@ class AiArr:
         self.radarr = Radarr(
             url=self.radarr_url,
             api_key=self.radarr_api_key,
+            root_dir_path=self.radarr_movies_path,
         )
         self.sonarr = Sonarr(
             url=self.sonarr_url,
             api_key=self.sonarr_api_key,
+            root_dir_path=self.sonarr_tvshows_path,
         )
         if self.gemini_enabled and self.gemini_api_key:
             self.gemini = Gemini(

--- a/server/src/services/radarr.py
+++ b/server/src/services/radarr.py
@@ -5,7 +5,7 @@ from .response import APIResponse # Import the APIResponse class
 from .api import Api # Import the new Api class
 
 class Radarr(Api):
-    def __init__(self, url: str, api_key: str):
+    def __init__(self, url: str, api_key: str, root_dir_path: str):
         """Initialize Radarr client.
         
         Args:
@@ -14,6 +14,7 @@ class Radarr(Api):
         """
         super().__init__(url=url, api_key=api_key, api_key_header_name="X-Api-Key", api_base_path="api/v3")
         self.logger = logging.getLogger(__name__)
+        self._root_dir_path = root_dir_path
         # self.url, self.api_key, and self.headers are now managed by the Api base class
 
     def get_quality_profiles(self, default_profile_id: Optional[int] = None) -> APIResponse:
@@ -83,7 +84,7 @@ class Radarr(Api):
         
         return api_response
 
-    def add_movie(self, tmdb_id: int, quality_profile_id: int, root_dir_path: str = "/movies", 
+    def add_movie(self, tmdb_id: int, quality_profile_id: int, 
                  monitor: bool = True, search_for_movie: bool = True) -> APIResponse:
         """Add a movie to Radarr using TMDb ID.
         
@@ -107,7 +108,7 @@ class Radarr(Api):
         data = {
             **movie_info,  # Include all movie details from lookup
             "qualityProfileId": quality_profile_id,
-            "rootFolderPath": root_dir_path,
+            "rootFolderPath": self._root_dir_path,
             "monitored": monitor,
             "addOptions": {
                 "searchForMovie": search_for_movie,

--- a/server/src/services/settings.py
+++ b/server/src/services/settings.py
@@ -48,11 +48,13 @@ class SettingsService:
             "url": {"value": "http://radarr:7878", "type": SettingType.URL, "description": "Radarr server URL"},
             "api_key": {"value": None, "type": SettingType.STRING, "description": "Radarr API key"},
             "default_quality_profile_id": {"value": None, "type": SettingType.INTEGER, "description": "Radarr Default quality profile ID"},
+            "movies_path": {"value": "/movies", "type": SettingType.STRING, "description": "Radarr downloads path"},
         },
         "sonarr": {
             "url": {"value": "http://sonarr:8989", "type": SettingType.URL, "description": "Sonarr server URL"},
             "api_key": {"value": None, "type": SettingType.STRING, "description": "Sonarr API key"},
             "default_quality_profile_id": {"value": None, "type": SettingType.INTEGER, "description": "Radarr Default quality profile ID"},
+            "tvshows_path": {"value": "/tv", "type": SettingType.STRING, "description": "Sonarr downloads path"},
         },
         "gemini": {
             "enabled": {"value": False, "type": SettingType.BOOLEAN, "description": "Enable or disable Gemini integration."},

--- a/server/src/services/sonarr.py
+++ b/server/src/services/sonarr.py
@@ -5,7 +5,7 @@ from .response import APIResponse # Import the APIResponse class
 from .api import Api # Import the new Api class
 
 class Sonarr(Api):
-    def __init__(self, url: str, api_key: str):
+    def __init__(self, url: str, api_key: str, root_dir_path: str):
         """Initialize Sonarr client.
         
         Args:
@@ -14,6 +14,7 @@ class Sonarr(Api):
         """
         super().__init__(url=url, api_key=api_key, api_key_header_name="X-Api-Key", api_base_path="api/v3")
         self.logger = logging.getLogger(__name__)
+        self._root_dir_path = root_dir_path
         # self.url, self.api_key, and self.headers are now managed by the Api base class
 
     def lookup_series(self, tmdb_id: str) -> APIResponse:
@@ -50,7 +51,7 @@ class Sonarr(Api):
         api_response.data = api_response.data[0]
         return api_response
 
-    def add_series(self, tmdb_id: str, quality_profile_id: int, root_dir_path: str = "/tv", 
+    def add_series(self, tmdb_id: str, quality_profile_id: int, 
                   language_profile_id: int = 1, season_folder: bool = True, 
                   monitor: bool = True, search_for_missing: bool = True) -> APIResponse:
         """Add a series to Sonarr using IMDB ID.
@@ -79,7 +80,7 @@ class Sonarr(Api):
             "title": series_data["title"],
             "tmdbId": tmdb_id,
             "qualityProfileId": quality_profile_id,
-            "rootFolderPath": root_dir_path,
+            "rootFolderPath": self._root_dir_path,
             "languageProfileId": language_profile_id,
             "seasonFolder": season_folder,
             "monitored": monitor,


### PR DESCRIPTION
This MR might be a good start to fix https://github.com/sqrlmstr5000/aiarr/issues/5.

I tested this locally and I was able to schedule download both in radarr and sonarr.

Unfortunately I don't have skills to update UI side of things if it's needed, but I can adjust other things if necessary.